### PR TITLE
Update submodules once before submodules are fetched

### DIFF
--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -29,8 +29,6 @@ function fetch_submodule() {
   echo "Pulling branch ${branch} for submodule $(pwd)"
   git fetch origin -u "${branch}":"${branch}" || return $?
   git merge "origin/${branch}" || return $?
-
-  git submodule update --init
 }
 
 function update_submodule() {
@@ -55,6 +53,8 @@ function fetch_artifacts() {
 }
 
 function update_submodules() {
+  git submodule update --init --recursive
+
   pushd $(dirname "$0")/../third_party/eventing
   update_submodule
   popd


### PR DESCRIPTION
Fixes #178

# Changes

Currently the git submodules are updated after the module is fetched. This leads to git not recognizing it as a git module. See https://github.com/knative-extensions/eventing-istio/actions/runs/7251090091/job/19752700238:

```
Currently in directory
/home/runner/work/eventing-istio/eventing-istio/third_party/eventing
Listing remotes
origin	https://github.com/knative-extensions/eventing-istio (fetch)
origin	https://github.com/knative-extensions/eventing-istio (push)
``` 

While when we update the submodules before the fetch, it recognizes it as a git submodule (https://github.com/knative-extensions/eventing-istio/actions/runs/7251130844/job/19752818040?pr=202):

```
~/work/eventing-istio/eventing-istio/third_party/eventing ~/work/eventing-istio/eventing-istio
Currently in directory
/home/runner/work/eventing-istio/eventing-istio/third_party/eventing
Listing remotes
origin	https://github.com/knative/eventing.git (fetch)
origin	https://github.com/knative/eventing.git (push)
```

- :bug: Update submodules before fetching