### PR TITLE
Checkout submodule instead of merge changes from origin

### DIFF
--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -28,7 +28,7 @@ function fetch_submodule() {
   branch=${1}
   echo "Pulling branch ${branch} for submodule $(pwd)"
   git fetch origin -u "${branch}":"${branch}" || return $?
-  git merge --no-edit "origin/${branch}" || return $?
+  git checkout "origin/${branch}" || return $?
 }
 
 function update_submodule() {


### PR DESCRIPTION
Avoid getting in a detached state for the submodules (e.g. as in https://github.com/knative-extensions/knobots/actions/runs/8645903879/job/23704066103)